### PR TITLE
クリップ一覧ページの作成

### DIFF
--- a/app/controllers/clip_posts_controller.rb
+++ b/app/controllers/clip_posts_controller.rb
@@ -6,7 +6,7 @@ class ClipPostsController < ApplicationController
       thumbnail: "https://clips-media-assets2.twitch.tv/ZVRdGDcuY5vZ5865K5yDqw/AT-cm%7CZVRdGDcuY5vZ5865K5yDqw-preview-480x272.jpg",
       streamer: "赤見かるび",
       title: "爆速一般通過SHAKA",
-      clip_created_at: "2023-07-18T20:51:57Z",
+      clip_created_at: "07-18 20:51:57",
       views: 327951,
       content_title: "デフォルト",
       tag_list: ["タグ1", "タグ2"]
@@ -27,7 +27,7 @@ class ClipPostsController < ApplicationController
     @clip_post.thumbnail = clip_data["thumbnail_url"]
     @clip_post.streamer = clip_data["broadcaster_name"]
     @clip_post.title = clip_data["title"]
-    @clip_post.clip_created_at = clip_data["created_at"]
+    @clip_post.clip_created_at = Time.parse(clip_data["created_at"]).strftime("%m-%d %H:%M:%S")
     @clip_post.views = clip_data["view_count"]
     @clip_post.content_title = clip_post_params[:content_title]
     @clip_post.tag_list = [clip_data["broadcaster_name"],game_name["name"],clip_post_params[:tag_list]]
@@ -40,7 +40,15 @@ class ClipPostsController < ApplicationController
   end
 
   def index
-    @clip_posts = ClipPost.all
+    if params[:clip_created_at]
+      @clip_posts = ClipPost.clip_created_at
+    elsif params[:most_views]
+      @clip_posts = ClipPost.most_views
+    elsif params[:created_at]
+      @clip_posts = ClipPost.created_at
+    else
+      @clip_posts = ClipPost.all.order(created_at: :desc)
+    end
   end
 
   def show
@@ -53,6 +61,9 @@ class ClipPostsController < ApplicationController
   end
 
   def destroy
+    clip_post = ClipPost.find(params[:id])
+    clip_post.destroy!
+    redirect_to clip_posts_path, success: "削除完了しました"
   end
 
   def likes
@@ -70,7 +81,7 @@ class ClipPostsController < ApplicationController
       thumbnail: clip_data["thumbnail_url"],
       streamer: clip_data["broadcaster_name"],
       title: clip_data["title"],
-      clip_created_at: clip_data["created_at"],
+      clip_created_at: Time.parse(clip_data["created_at"]).strftime("%m-%d %H:%M:%S"),
       views: clip_data["view_count"],
       content_title: params[:content_title],
       tag_list: [clip_data["broadcaster_name"],game_name["name"],params[:tag_list]]

--- a/app/models/clip_post.rb
+++ b/app/models/clip_post.rb
@@ -3,6 +3,10 @@ class ClipPost < ApplicationRecord
   has_many :likes
 
   acts_as_taggable
+
+  scope :clip_created_at, -> { order(clip_created_at: :desc) }
+  scope :created_at, -> { order(created_at: :desc) }
+  scope :most_views, -> { order(views: :desc) }
   
   def liked_by?(user)
     likes.where(user_id: user.id).exists?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,8 @@ class User < ApplicationRecord
   has_many :like_clip_posts, through: :likes, source: :clip_posts
 
   validates :password, confirmation: true
+
+  def own?(object)
+    id == object.user_id
+  end
 end

--- a/app/services/twitch_api.rb
+++ b/app/services/twitch_api.rb
@@ -58,6 +58,3 @@ class TwitchApi
     return nil
   end
 end
-
-a = TwitchApi.new
-puts a.get_game_name("32982")

--- a/app/views/clip_posts/_crud_menus.html.erb
+++ b/app/views/clip_posts/_crud_menus.html.erb
@@ -1,0 +1,19 @@
+<ul>
+  <% if current_user.own?(clip_post) %>
+    <li class='list-inline-item'>
+      <%= link_to edit_clip_post_path(clip_post) do %>
+        <i class="fa-solid fa-file-pen"></i>
+      <% end %>
+    </li>
+    <li class='list-inline-item'>
+      <%= link_to clip_post_path(clip_post), method: :delete do %>
+        <i class="fa-solid fa-trash-can"></i>
+      <% end %>
+    </li>
+  <% end %>
+  <li class='list-inline-item float-end'>
+    <%= link_to edit_clip_post_path(clip_post) do %>
+      <i class="fa-regular fa-thumbs-up"></i>
+    <% end %>
+  </li>
+</ul>

--- a/app/views/clip_posts/_form.html.erb
+++ b/app/views/clip_posts/_form.html.erb
@@ -1,28 +1,25 @@
 <div class="container border-dark border-1 border">
-  <div class="row mb-3 bg-white">
-    <div class="col h3 ms-3"><%= preview_post.streamer %></div>
+  <div class="row mt-3 mb-3 bg-white">
+    <div class="col h3 ms-3"><%= clip_post.streamer %></div>
     <div class="col d-flex justify-content-end align-items-end small">
-      <div class="border-bottom border-dark text-muted"><%= preview_post.clip_created_at %></div>
+      <div class="border-bottom border-dark text-muted"><%= clip_post.clip_created_at %></div>
     </div>
   </div>
   <div class="row mb-3 bg-white">
-    <div class="text-center mb-2"><%= preview_post.title %></div>
+    <div class="text-center mb-2"><%= clip_post.title %></div>
     <div class="d-flex justify-content-center mb-2">
       <div class="ratio" style="--bs-aspect-ratio: 56.25%; width: 500px;">
-        <%= image_tag preview_post.thumbnail %>
+        <%= image_tag clip_post.thumbnail %>
       </div>
     </div>
     <div class="mb-3">
-      <%= render 'tag_form.html.erb', preview_post: preview_post %>
+      <%= render 'tag_form.html.erb', clip_post: clip_post %>
     </div>
     <div class="d-flex justify-content-center">
-      <div class="row form-control border" style="width: 98%"><%= preview_post.content_title %></div>
+      <div class="row form-control border bg-white" style="width: 98%"><%= clip_post.content_title %></div>
     </div>
   </div>
-  <div class="row mb-3 bg-white">
-    <div class="d-flex align-items-center justify-content-end">
-      <i class="fa-regular fa-thumbs-up"></i>
-      <div class="text-end">いいね！</div>
-    </div>
+  <div class="row mb-3 bg-white ps-3 pe-3">
+    <%= render 'crud_menus', clip_post: clip_post %>
   </div>
 </div>

--- a/app/views/clip_posts/_preview_form.html.erb
+++ b/app/views/clip_posts/_preview_form.html.erb
@@ -13,7 +13,7 @@
       </div>
     </div>
     <div class="mb-3">
-      <%= render 'tag_form.html.erb', preview_post: preview_post %>
+      <%= render 'tag_form.html.erb', clip_post: preview_post %>
     </div>
     <div class="d-flex justify-content-center">
       <div class="row form-control border" style="width: 98%"><%= preview_post.content_title %></div>

--- a/app/views/clip_posts/_tag_form.html.erb
+++ b/app/views/clip_posts/_tag_form.html.erb
@@ -1,5 +1,5 @@
 <div class="d-flex flex-wrap">
-  <% preview_post.tag_list.each do |tag| %>
+  <% clip_post.tag_list.each do |tag| %>
     <div class="flex-item ms-3"><p class="tag_wrapper"><%= tag %></p></div>
   <% end %>
 </div>

--- a/app/views/clip_posts/index.html.erb
+++ b/app/views/clip_posts/index.html.erb
@@ -1,3 +1,14 @@
 <%= render 'shared/title_bar', title: "投稿一覧" %>
-
+<div class="bg-light">
 <a href="https://id.twitch.tv/oauth2/authorize?client_id=11gshrju07m1wwgyqgpjrir3scixrl&redirect_uri=http://localhost:3000/clip_posts&response_type=token&scope=bits:read">Twitch認証</a>
+<div class="container d-flex justify-content-end bg-light">
+  <%= link_to '時系列順', clip_posts_path(clip_created_at: "true"), class: "ms-3" %>
+  <%= link_to '再生数順', clip_posts_path(most_views: "true"), class: "ms-3" %>
+  <%= link_to '投稿順', clip_posts_path(created_at: "true"), class: "ms-3" %>
+</div>
+<% @clip_posts.each do |clip_post| %>
+  <div class="container mb-1 bg-light">
+    <%= render 'form.html.erb', clip_post: clip_post %>
+  </div>
+<% end %>
+</div>


### PR DESCRIPTION
- post投稿機能を調整。twitch apiの内容も保存できるように
- indexページのレイアウト作成
- 時系列、投稿順、視聴数順でそれぞれ並び替え表示ができるように、indexアクションで並び替え
- indexアクションへ渡す値によって、並べ替えの種類を判別できるように
- clip_created_atの表記を人間が見やすい表記に変更。変更して保存するように。
- 編集ボタン、削除ボタン、いいねボタンを追加。
- 編集、削除ボタンは、クリップ投稿者しか表示されないように設定