### PR TITLE
詳細ページ作成,embed_urlカラムの追加

### DIFF
--- a/app/controllers/clip_posts_controller.rb
+++ b/app/controllers/clip_posts_controller.rb
@@ -9,7 +9,8 @@ class ClipPostsController < ApplicationController
       clip_created_at: "07-18 20:51:57",
       views: 327951,
       content_title: "デフォルト",
-      tag_list: ["タグ1", "タグ2"]
+      tag_list: ["タグ1", "タグ2"],
+      embed_url: "https://clips.twitch.tv/embed?clip=BumblingShinyEndiveVoHiYo-G4qhbaXZCTBN3WXp"
     )
   end
 
@@ -31,6 +32,7 @@ class ClipPostsController < ApplicationController
     @clip_post.views = clip_data["view_count"]
     @clip_post.content_title = clip_post_params[:content_title]
     @clip_post.tag_list = [clip_data["broadcaster_name"],game_name["name"],clip_post_params[:tag_list]]
+    @clip_post.embed_url = clip_data["embed_url"]
 
     if @clip_post.save
       redirect_to clip_posts_path, success: "保存が完了しました"
@@ -52,6 +54,8 @@ class ClipPostsController < ApplicationController
   end
 
   def show
+    @clip_post = ClipPost.find(params[:id])
+    render :layout => 'compact'
   end
 
   def edit
@@ -84,7 +88,8 @@ class ClipPostsController < ApplicationController
       clip_created_at: Time.parse(clip_data["created_at"]).strftime("%m-%d %H:%M:%S"),
       views: clip_data["view_count"],
       content_title: params[:content_title],
-      tag_list: [clip_data["broadcaster_name"],game_name["name"],params[:tag_list]]
+      tag_list: [clip_data["broadcaster_name"],game_name["name"],params[:tag_list]],
+      embed_url: clip_data["embed_url"]
     )
 
    respond_to do |format|

--- a/app/views/clip_posts/_comment_crud_menus.html.erb
+++ b/app/views/clip_posts/_comment_crud_menus.html.erb
@@ -1,0 +1,17 @@
+<ul>
+  <% if current_user.own?(clip_post) %>
+    <li class='list-inline-item'>
+      <%= link_to edit_clip_post_path(clip_post) do %>
+        <i class="fa-solid fa-file-pen"></i>
+      <% end %>
+    </li>
+    <li class='list-inline-item'>
+      <%= link_to clip_post_path(clip_post), method: :delete do %>
+        <i class="fa-solid fa-trash-can"></i>
+      <% end %>
+    </li>
+  <% end %>
+  <li class='list-inline-item float-end'>
+    <%= render 'like_button', clip_post: clip_post %>
+  </li>
+</ul>

--- a/app/views/clip_posts/_comment_like.html.erb
+++ b/app/views/clip_posts/_comment_like.html.erb
@@ -1,0 +1,7 @@
+<%= link_to likes_path(clip_post_id: clip_post.id),
+       id: "like_button_#{clip_post.id}", 
+       class:'float-right',
+       method: :post,
+      remote: true do %>
+  <i class="fa-regular fa-thumbs-up"></i>
+<% end %>

--- a/app/views/clip_posts/_comment_like_button.html.erb
+++ b/app/views/clip_posts/_comment_like_button.html.erb
@@ -1,0 +1,5 @@
+<% if current_user.like?(clip_post) %>
+  <%= render 'clip_posts/unlike',{ clip_post: clip_post } %>
+<% else %>
+  <%= render 'clip_posts/like', { clip_post: clip_post } %>
+<% end %>

--- a/app/views/clip_posts/_comment_unlike.html.erb
+++ b/app/views/clip_posts/_comment_unlike.html.erb
@@ -1,0 +1,7 @@
+<%= link_to like_path(current_user.likes.find_by(clip_post_id: clip_post.id)),
+      id: "like_button_#{clip_post.id}",
+      class: 'float-right',
+      method: :delete, 
+      remote: true do %>
+  <i class="fa-solid fa-thumbs-up"></i><% if false %>#黒いスター（ブックマーク済みを示す）link_to 先は、bookmarks#destroyで押すとブックマークを消す<% end %>
+<% end %>

--- a/app/views/clip_posts/_form.html.erb
+++ b/app/views/clip_posts/_form.html.erb
@@ -8,9 +8,11 @@
   <div class="row mb-3 bg-white">
     <div class="text-center mb-2"><%= clip_post.title %></div>
     <div class="d-flex justify-content-center mb-2">
+    <%= link_to clip_post_path(clip_post) do %>
       <div class="ratio" style="--bs-aspect-ratio: 56.25%; width: 500px;">
         <%= image_tag clip_post.thumbnail %>
       </div>
+    <% end %>
     </div>
     <div class="mb-3">
       <%= render 'tag_form.html.erb', clip_post: clip_post %>

--- a/app/views/clip_posts/show.html.erb
+++ b/app/views/clip_posts/show.html.erb
@@ -1,0 +1,62 @@
+<div class="container bg-light p-3 vh-100">
+
+  <!-- メイン画面 -->
+  <div class="container border-dark border-1 border">
+    <div class="row mb-3 bg-white">
+      <div class="col h3 ms-3"><%= @clip_post.streamer %></div>
+      <div class="col d-flex justify-content-end align-items-end small">
+        <div class="border-bottom border-dark"><%= @clip_post.clip_created_at %></div>
+      </div>
+    </div>
+    <div class="row mb-3 bg-white">
+      <div class="text-center mb-2"><%= @clip_post.title %></div>
+      <div class="d-flex justify-content-center mb-2">
+        <div class="ratio" style="--bs-aspect-ratio: 56.25%;">
+          <iframe src="<%= @clip_post.embed_url %>&amp;parent=localhost" allowfullscreen="" loading="lazy" style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; border: none;"></iframe>
+        </div>
+      </div>
+      <div class="mb-3">
+        <%= render 'tag_form.html.erb', clip_post: @clip_post %>
+      </div>
+      <div class="d-flex justify-content-center">
+        <div class="row form-control border" style="width: 98%">コメントコンテンツ</div>
+      </div>
+    </div>
+    <div class="row mb-3 bg-white">
+      <div class="d-flex align-items-center justify-content-end">
+        <i class="fa-regular fa-thumbs-up"></i>
+        <div class="text-end">いいね！</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- コメントの投稿フォーム -->
+  <div class="container border-dark border-1 border mt-2">
+    <div class="text-center h5 mt-3">コメント一覧</div>
+    <%= form_with(model: @user, url: users_path(@user), method: "post") do |form| %>
+      <div class="mb-2 row mt-5">
+        <div class="mb-3 text-center">
+          <div class="d-flex flex-column align-items-center">
+            <%= form.text_field :email, class: "form-control mb-3", placeholder: "コメントを入力してください" %>
+            <%= form.submit '投稿する', class: 'btn btn-primary' %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+    <!-- コメント一覧 -->
+    <div class="mb-2">
+      <div class="form-control border">
+        <p>コメントですよ</p>
+        <div class="text-muted small">07-20 14:03:48</div>
+        <%= render 'comment_crud_menus', clip_post: @clip_post %>
+      </div>
+    </div>
+    <div class="mb-2">
+      <div class="form-control border">
+        <p>コメントですよ</p>
+        <div class="text-muted small">07-20 14:03:48</div>
+        <%= render 'comment_crud_menus', clip_post: @clip_post %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/compact.html.erb
+++ b/app/views/layouts/compact.html.erb
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>ShareClip</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+  </head>
+
+  <body>
+    <div class="row vh-100">
+      <%= render 'shared/compact_left_sidebar' %>
+      <div class="col-10">
+        <%= yield %>
+      </div>
+      <%= render 'shared/compact_right_sidebar' %>
+    </div>
+    <%= render 'shared/footer' %>
+  </body>
+</html>

--- a/app/views/shared/_compact_left_sidebar.html.erb
+++ b/app/views/shared/_compact_left_sidebar.html.erb
@@ -1,0 +1,20 @@
+<div class="col-1">
+  <div class="d-flex flex-column mt-3 ms-4">
+    <!-- 編集リンク -->
+    <div class="flex-item mb-3">
+      <%= link_to clip_posts_path do %>
+        <i class="fa-solid fa-list fa-4x" style="color: gray;"></i>
+      <% end %>
+    </div>
+    <div class="flex-item mb-3">
+      <%= link_to '#' do %>
+        <i class="fa-solid fa-thumbs-up fa-4x" style="color: gray;"></i>
+      <% end %>
+    </div>
+    <div class="flex-item mb-3 mt-2">
+      <%= link_to new_clip_post_path do %>
+        <i class="fa-solid fa-pencil fa-4x" style="color: gray;"></i>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_compact_right_sidebar.html.erb
+++ b/app/views/shared/_compact_right_sidebar.html.erb
@@ -1,0 +1,15 @@
+<div class="col-1 justify-content-end d-flex">
+  <div class="d-flex flex-column mt-3 me-4">
+    <!-- 編集リンク -->
+    <div class="flex-item mb-3">
+      <%= link_to  new_user_path do %>
+        <i class="fa-solid fa-user-plus fa-4x" style="color: gray;"></i>
+      <% end %>
+    </div>
+    <div class="flex-item mb-3 mt-3">
+      <%= link_to login_path do %>
+        <i class="fa-solid fa-arrow-right-to-bracket fa-4x" style="color: gray;"></i>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/db/migrate/20230826030412_create_clip_posts.rb
+++ b/db/migrate/20230826030412_create_clip_posts.rb
@@ -3,6 +3,7 @@ class CreateClipPosts < ActiveRecord::Migration[6.1]
     create_table :clip_posts do |t|
       t.references :user, null: false
       t.string :url, null: false
+      t.string :embed_url
       t.string :thumbnail
       t.string :streamer
       t.string :title

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,6 +15,7 @@ ActiveRecord::Schema.define(version: 2023_08_26_030848) do
   create_table "clip_posts", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "url", null: false
+    t.string "embed_url"
     t.string "thumbnail"
     t.string "streamer"
     t.string "title"


### PR DESCRIPTION
- 詳細ページのレイアウト作成
- embed_urlに動画埋め込み用のurlを保存するためclip_postにカラムを追加
- embed_urlをもとにtwitchの動画プレイヤーでの動画再生を実行できるように
- indexからthumbnailをクリックすることで詳細ページに推移できるように
- コメント機能周りは次のブランチで整える